### PR TITLE
Added support to run the tests gainst the V2 version of this module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# V0.1.8
+- Added support to run the tests against the V2 module of this module
 # V0.1.7
 - Fixed bug in RHEL 8 support
 # V0.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ RUN rm -rf env && python3 -m venv env && env/bin/pip install -U pip
 # installed as a V2 module when it contains a inmanta_plugins directory.
 RUN if [ -e "inmanta_plugins" ]; then \
     env/bin/pip install -r requirements.dev.txt -c requirements.freeze; \
-    env/bin/inmanta module install .; \
+    rm -rf ./dist; \
+    env/bin/inmanta module build; \
+    env/bin/pip install -c requirements.freeze ./dist/*.whl; \
 else \
     env/bin/pip install -r requirements.dev.txt -c requirements.freeze; \
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,18 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN mkdir -p /module/postgresql
 WORKDIR /module/postgresql
 
-RUN python3 -m venv env
-RUN env/bin/pip install -U pip
+# Copy the entire module into the container
+COPY . .
 
-COPY requirements.freeze requirements.freeze
-COPY requirements.dev.txt requirements.dev.txt
-RUN env/bin/pip install -r requirements.dev.txt -c requirements.freeze
-
-COPY module.yml module.yml
-COPY model model
-COPY templates templates
-COPY plugins plugins
-COPY tests tests
+RUN rm -rf env && python3 -m venv env && env/bin/pip install -U pip
+# The module set tests convert the module into a V2 module, install it in the test
+# environment and run the tests against it. This code ensures that the module is
+# installed as a V2 module when it contains a inmanta_plugins directory.
+RUN if [ -e "inmanta_plugins" ]; then \
+    env/bin/pip install -r requirements.dev.txt -c requirements.freeze; \
+    env/bin/inmanta module install .; \
+else \
+    env/bin/pip install -r requirements.dev.txt -c requirements.freeze; \
+fi
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/module.yml
+++ b/module.yml
@@ -1,4 +1,4 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: postgresql
-version: 0.1.7
+version: 0.1.8.dev1644331918

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def start_container():
         .stdout.decode("utf-8")
         .strip()
     )
-    wait_until_postgresql_process_is_up(docker_container)
+    wait_until_postgresql_process_is_up(container_id)
     print(f"Started container with id {container_id}")
     return container_id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
-import uuid
 import time
+import uuid
 
 import pytest
 from pytest import fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import uuid
+import time
 
 import pytest
 from pytest import fixture
@@ -62,8 +63,35 @@ def start_container():
         .stdout.decode("utf-8")
         .strip()
     )
+    wait_until_postgresql_process_is_up(docker_container)
     print(f"Started container with id {container_id}")
     return container_id
+
+
+def wait_until_postgresql_process_is_up(docker_container) -> None:
+    """
+    Execute a busy wait until the PostgreSQL process has finished starting.
+    An exception is raised after 30 failed is ready checks.
+    """
+    retries = 30
+    while retries > 0:
+        try:
+            subprocess.run(
+                [
+                    "sudo",
+                    "docker",
+                    "exec",
+                    f"{docker_container}",
+                    "pg_isready",
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            retries -= 1
+            time.sleep(1)
+        else:
+            return
+    raise Exception("Timeout while waiting for PostgreSQL server to start")
 
 
 def stop_container(container_id: str):


### PR DESCRIPTION
# Description

The module set tests convert the module into a V2 module, install it in a venv and run the tests against that. This PR makes sure that the postgresql module supports this while running in Docker.

Part of https://github.com/inmanta/irt/issues/898

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
