### PR TITLE
Release dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# V0.1.9
+- Release dependency updates
 # V0.1.8
 - Added support to run the tests against the V2 module of this module
 # V0.1.7

--- a/module.yml
+++ b/module.yml
@@ -1,4 +1,4 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: postgresql
-version: 0.1.8
+version: 0.1.9.dev1647009660


### PR DESCRIPTION
# Description

This PR has the goal to release 183a1ae6bfe9c2b8fc210aef0c4e7e31c2461900. That change updates the `PYTHON_VER` argument of the dockerfile from 3.6.11 to 3.9.6. With this change released the module set tests should succeed again. There is no need to add support for these tests to run on Python3.6 as this is an OSS module only. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
