### PR TITLE
add ENV DEBIAN_FRONTEND=noninteractive to dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# V0.2.2
+- add ENV DEBIAN_FRONTEND=noninteractive to dockerfile
+
 # V0.2.1
 - Add pyproject.toml file and set asyncio_mode to auto
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,21 @@ ARG BUILDDIR="/tmp/build"
 ARG PYTHON_VER="3.9.6"
 ARG PIP_INDEX_URL
 ARG PIP_PRE
+ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR ${BUILDDIR}
 
 RUN apt-get update -qq && \
-apt-get upgrade -y
+    apt-get upgrade -y
 RUN apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev curl libbz2-dev
 RUN apt-get install wget gcc make zlib1g-dev -y -qq > /dev/null 2>&1 && \
-wget --quiet https://www.python.org/ftp/python/${PYTHON_VER}/Python-${PYTHON_VER}.tgz > /dev/null 2>&1 && \
-tar zxf Python-${PYTHON_VER}.tgz && \
-cd Python-${PYTHON_VER} && \
-./configure  > /dev/null 2>&1 && \
-make > /dev/null 2>&1 && \
-make install > /dev/null 2>&1 && \
-rm -rf ${BUILDDIR}
+    wget --quiet https://www.python.org/ftp/python/${PYTHON_VER}/Python-${PYTHON_VER}.tgz > /dev/null 2>&1 && \
+    tar zxf Python-${PYTHON_VER}.tgz && \
+    cd Python-${PYTHON_VER} && \
+    ./configure  > /dev/null 2>&1 && \
+    make > /dev/null 2>&1 && \
+    make install > /dev/null 2>&1 && \
+    rm -rf ${BUILDDIR}
 
 RUN apt-get install -y openssh-server sudo git supervisor python3-venv
 
@@ -44,8 +45,8 @@ RUN if [ -e "inmanta_plugins" ]; then \
     rm -rf ./dist; \
     env/bin/inmanta module build; \
     env/bin/pip install -c requirements.freeze ./dist/*.whl; \
-else \
+    else \
     env/bin/pip install -r requirements.dev.txt -c requirements.freeze; \
-fi
+    fi
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/module.yml
+++ b/module.yml
@@ -1,4 +1,4 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: postgresql
-version: 0.2.1
+version: 0.2.2.dev1652866145


### PR DESCRIPTION
# Description

currently some test builds breaks as some installation require to be done interactively. 
by adding ENV DEBIAN_FRONTEND=noninteractive, automatic selections should be done
and the scripts will not be interrupted anymore. 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
