### PR TITLE
Remove apt-get upgrade from Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.2 - ?
 
+- Don't execute the apt-get upgrade command in the Dockerfile for the tests to prevent issue with invalid locale
 
 ## v0.4.1 - 2023-04-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR ${BUILDDIR}
 
-RUN apt-get update -qq && \
-    apt-get upgrade -y
+RUN apt-get update -qq
 RUN apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev curl libbz2-dev
 RUN apt-get install wget gcc make zlib1g-dev -y -qq > /dev/null 2>&1 && \
     wget --quiet https://www.python.org/ftp/python/${PYTHON_VER}/Python-${PYTHON_VER}.tgz > /dev/null 2>&1 && \


### PR DESCRIPTION
# Description

The PostgreSQL docker image breaks when `apt-get upgrade` is executed in it (see: https://github.com/docker-library/postgres/issues/1073). I don't see a reason why we need that command to be invoked. As such, I removed it.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~