### PR TITLE
Install PG13 by default instead of PG10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v0.4.4 - ?
+## v1.0.0 - ?
 
+- Install PG13 by default instead of PG10
 
 ## v0.4.3 - 2023-06-30
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -13,12 +13,12 @@ entity PostgresqlServer extends ip::services::Server:
     bool managed = true
     int log_min_duration_statement = -1
     bool pg_stat_statements=false
-    int pg_version = 10
+    int pg_version = 13
 end
 
 entity PostgresqlTools:
     """Install the postgresql client tools on a host."""
-    int pg_version = 10
+    int pg_version = 13
 end
 
 PostgresqlServer.databases [0:] -- Database.server [1]

--- a/module.yml
+++ b/module.yml
@@ -1,4 +1,4 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: postgresql
-version: 0.4.4.dev0
+version: 1.0.0.dev0


### PR DESCRIPTION
# Description

Install PG13 by default instead of PG10. The RPM repositories for PG10 were removed because it's end of life.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~