### PR TITLE
Use same python version inside and ouside test container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.3 - ?
 
+- Use the same python inside and outside of container while running the tests
 
 ## v1.0.2 - 2023-11-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG PG_MAJOR_VERSION
 FROM postgres:${PG_MAJOR_VERSION}-bullseye
 ARG PG_MAJOR_VERSION
+ARG PYTHON_VER
 
 # Store the Postgres major version into an env variable to make it available from within the tests
 ENV PG_MAJOR_VERSION=${PG_MAJOR_VERSION}
 
 ARG BUILDDIR="/tmp/build"
-ARG PYTHON_VER="3.9.6"
 ARG PIP_INDEX_URL
 ARG PIP_PRE
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import time
 import uuid
+import sys
 
 import pytest
 from pytest import fixture
@@ -49,6 +50,11 @@ def start_container(pg_version: int = 10):
     docker_build_cmd = ["sudo", "docker", "build", ".", "-t", image_name]
     docker_build_cmd.append("--build-arg")
     docker_build_cmd.append(f"PG_MAJOR_VERSION={pg_version}")
+
+    # Set PYTHON_VER build argument
+    python_version='.'.join([str(part) for part in sys.version_info[0:3]])
+    docker_build_cmd.append("--build-arg")
+    docker_build_cmd.append(f"PYTHON_VER={python_version}")
 
     pip_index_url = os.environ.get("PIP_INDEX_URL", None)
     if pip_index_url is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@
 """
 import os
 import subprocess
+import sys
 import time
 import uuid
-import sys
 
 import pytest
 from pytest import fixture
@@ -52,7 +52,7 @@ def start_container(pg_version: int = 10):
     docker_build_cmd.append(f"PG_MAJOR_VERSION={pg_version}")
 
     # Set PYTHON_VER build argument
-    python_version='.'.join([str(part) for part in sys.version_info[0:3]])
+    python_version = ".".join([str(part) for part in sys.version_info[0:3]])
     docker_build_cmd.append("--build-arg")
     docker_build_cmd.append(f"PYTHON_VER={python_version}")
 


### PR DESCRIPTION
# Description

This PR makes sure that the Python version used inside and outside of the container to run the test suite, is the same. This is required because the freeze file used inside the container, to install the required dependencies, is generated outside of the container.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~